### PR TITLE
ActiveStorage で画像アップロードを実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ gem 'bootsnap', require: false
 # gem "sassc-rails"
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-# gem "image_processing", "~> 1.2"
+gem 'image_processing', '~> 1.2'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,7 @@ DEPENDENCIES
   erb_lint
   faker
   i18n_generators
+  image_processing (~> 1.2)
   importmap-rails
   jbuilder
   kaminari

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction icon]
     devise_parameter_sanitizer.permit(:sign_up, keys:)
     devise_parameter_sanitizer.permit(:account_update, keys:)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction icon]
+    keys = %i[icon name postal_code address self_introduction]
     devise_parameter_sanitizer.permit(:sign_up, keys:)
     devise_parameter_sanitizer.permit(:account_update, keys:)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.order(:id).page(params[:page])
+    @users = User.with_attached_icon.order(:id).page(params[:page])
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,8 @@ class User < ApplicationRecord
   private
 
   def icon_type
-    return if icon_atacched? && icon.blob.content_type.in?(%('image/jpeg image/png image/gif'))
+    extention = %('image/jpeg image/png image/gif')
+    return if icon_atacched? && icon.blob.content_type.in?(extention)
 
     errors.add(:icon, 'はjpegまたはpngまたはgif形式でアップロードしてください')
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,25 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_one_attached :icon
+
+  validate :icon_type
+
+  has_one_attached :icon do |attachable|
+    attachable.variant :thumbnail, resize_to_limit: [200, 200]
+    attachable.variant :preview, resize_to_limit: [100, 100]
+  end
+
+  def icon_atacched?
+    icon.attached?
+  end
+
+  private
+
+  def icon_type
+    return if icon_atacched? && icon.blob.content_type.in?(%('image/jpeg image/png image/gif'))
+
+    errors.add(:icon, 'はjpegまたはpngまたはgif形式でアップロードしてください')
+  end
 end

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -1,4 +1,10 @@
 <div class="field">
+  <%= f.label :icon %><br />
+  <%= image_tag @user.icon.variant(:preview) if @user.icon_atacched? %><br />
+  <%= f.file_field :icon , accept: 'image/png,image/gif,image/jpeg' %>
+</div>
+
+<div class="field">
   <%= f.label :name %><br />
   <%= f.text_field :name %>
 </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,6 +1,13 @@
 <div id="<%= dom_id user %>">
 
   <p>
+    <strong><%= User.human_attribute_name(:icon) %>:</strong>
+      <% if user.icon.present? %>
+      <%= image_tag user.icon.variant(:thumbnail) %>
+      <% end %>
+  </p>
+
+  <p>
     <strong><%= User.human_attribute_name(:email) %>:</strong>
     <%= user.email %>
   </p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,6 @@ module BooksApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.active_storage.variant_processor = :mini_magick
   end
 end

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,3 +15,4 @@ ja:
         postal_code: 郵便番号
         address: 住所
         self_introduction: 自己紹介文
+        icon: プロフィール画像

--- a/db/migrate/20240627014243_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240627014243_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_02_023317) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_27_014243) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "books", force: :cascade do |t|
     t.string "title"
     t.text "memo"
@@ -36,4 +64,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_02_023317) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
# 必須要件
- [x] ユーザーが自分のアイコン画像をアップロードできるようにする
- [x] ユーザー一覧画面とユーザー詳細画面にアイコンを表示する（未アップロードなら何も表示しない）
- [x] 画像を表示する際、大きすぎる画像は適切なサイズにリサイズする（ファイルの容量を小さくしてネットワークの負荷を減らす）
- [x] 画像アップロード用に追加した項目はi18nのYAMLファイルを編集して項目名を表示させよう（英語化は考慮不要）
- [x] 一覧画面に画像を表示させる場合はN+1問題を起こさないようにしよう
# 歓迎要件
- [x] プロフィール編集画面にも現在設定されているアイコンを表示する
- [x] アップロード可能なファイルはjpg, png, gifの3種類だけに限定する

# スクショ
- [x] ユーザー一覧画面とユーザー詳細画面のスクリーンショットを載せる
- [x] rubocopとerblintをパスさせる（要スクリーンショット）
